### PR TITLE
resolves #2: now a multitask

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Task targets, files and options may be specified according to the Grunt
 
 ## Usage Example
 
+*As of v1.0.0, bower-install-simple is now a "multitask", and must be configured accordingly.* 
+
 Assuming we have the following build environment:
 
 - `Gruntfile.js`:
@@ -70,10 +72,18 @@ Assuming we have the following build environment:
 // [...]
 grunt.initConfig({
     "bower-install-simple": {
-        options: {
-            color:       true,
-            production:  false,
-            directory:   "lib"
+        main: {
+            options: {
+                color:       true,
+                production:  true,
+                directory:   "lib"
+            }
+        },
+        test: {
+            options: {
+                production:  false,
+                directory:   "test",
+            }
         }
     }
 });

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name":        "grunt-bower-install-simple",
     "homepage":    "http://github.com/rse/grunt-bower-install-simple",
     "description": "Grunt Task for Installing Bower Dependencies",
-    "version":     "0.9.3",
+    "version":     "1.0.0",
     "license":     "MIT",
     "author": {
         "name":    "Ralf S. Engelschall",

--- a/tasks/grunt-bower-install-simple.js
+++ b/tasks/grunt-bower-install-simple.js
@@ -32,7 +32,7 @@ var bower         = require("bower");
 var bowerRenderer = require("bower/lib/renderers/StandardRenderer");
 
 module.exports = function (grunt) {
-    grunt.registerTask("bower-install-simple", "Install Bower Dependencies", function () {
+    grunt.registerMultiTask("bower-install-simple", "Install Bower Dependencies", function () {
         /*  prepare options  */
         var options = this.options({
             /*  bower configuration options (renderer specific)  */


### PR DESCRIPTION
- breaks backwards compatibility, which is why I bumped the major #
- updated `README.md` w/ warning and new example

Since this is a **breaking change** you may not want to accept this PR.  If not, that is fine, and I can maintain a separate fork.

thanks,  
Chris
