### PR TITLE
allow to run bower update task instead of bower install

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ grunt.loadNpmTasks("grunt-bower-install-simple");
   This defaults to `bower_components`.
   The equivalent of `bower --config.directory=<dir>`.
 
+- `update` (default `false`): Makes the plugin run `bower update` instead of `bower install`.
+
 ## Task Calling
 
 _Run this task with the `grunt bower-install-simple` command._

--- a/tasks/grunt-bower-install-simple.js
+++ b/tasks/grunt-bower-install-simple.js
@@ -39,6 +39,9 @@ module.exports = function (grunt) {
             color:        true,               /*  bower --config.color=true        */
             cwd:          process.cwd(),      /*  bower --config.cwd=`pwd`         */
 
+            /*  bower task options */
+            update:       false,              /*  true to run 'bower update'       */
+
             /*  bower install command options  */
             forceLatest:  false,              /*  bower install --force-latest     */
             production:   false,              /*  bower install --production       */
@@ -63,7 +66,11 @@ module.exports = function (grunt) {
             color:          options.color,
             cwd:            options.cwd
         });
-        bower.commands.install([], {
+
+
+        /* run bower install or update task */
+        var task = options.update ? bower.commands.update : bower.commands.install;
+        task([], {
             "force-latest": options.forceLatest,
             production:     options.production
         }, {


### PR DESCRIPTION
- to run bower update, one can now add 'update:true' to the options
