### PR TITLE
Let bower handle it's own defaults

### DIFF
--- a/tasks/grunt-bower-install-simple.js
+++ b/tasks/grunt-bower-install-simple.js
@@ -24,6 +24,7 @@
 
 /* global module:  false */
 /* global require: false */
+/* global process: false */
 
 /*  foreign modules  */
 var chalk         = require("chalk");
@@ -31,10 +32,23 @@ var bower         = require("bower");
 var bowerRenderer = require("bower/lib/renderers/StandardRenderer");
 
 module.exports = function (grunt) {
-    "use strict";
-    grunt.registerMultiTask("bower-install-simple", "Install Bower Dependencies", function () {
+    grunt.registerMultiTask("bower-install-simple", "Install or Update Bower Dependencies", function () {
         /*  prepare options  */
-        var options = this.options({});
+        var options = this.options({
+            /*  bower configuration options (renderer specific)  */
+            color:        true,               /*  bower --config.color=true        */
+            cwd:          process.cwd(),      /*  bower --config.cwd=`pwd`         */
+
+            /*  bower task options */
+            update:       false,              /*  true to run 'bower update'       */
+
+            /*  bower install command options  */
+            forceLatest:  false,              /*  bower install --force-latest     */
+            production:   false,              /*  bower install --production       */
+
+            /*  bower configuration options (general)  */
+            interactive:  true                /*  bower --config.interactive=true  */
+        });
         grunt.verbose.writeflags(options, "Options");
 
         /*  display header to explicitly inform user about our operation  */
@@ -47,8 +61,24 @@ module.exports = function (grunt) {
         /*  run programatically the functionality behind
             the official "bower install" command  */
         var done = this.async();
-        var renderer = new bowerRenderer("install", options);
-        bower.commands.install([], options, options)
+        var renderer = new bowerRenderer("install", {
+            color:          options.color,
+            cwd:            options.cwd
+        });
+
+        /* run bower install or update task */
+        var task = options.update ? bower.commands.update : bower.commands.install;
+        var cfgOptions = {
+            interactive:    options.interactive,
+            cwd:            options.cwd
+        };
+        if(options.directory) {
+          cfgOptions.directory = options.directory;
+        }
+        task([], {
+            "force-latest": options.forceLatest,
+            production:     options.production
+        }, cfgOptions)
         .on("log", function (log) {
             renderer.log(log);
         })
@@ -67,5 +97,6 @@ module.exports = function (grunt) {
         });
     });
 };
+
 
 


### PR DESCRIPTION
Fixes #9. 
Remove all local options and just pass them through to bower to handle it's own defaulting. A bit ham-handed, as it ends up sending some unnecessary cruft to bower, but shouldn't hurt anything.
