### PR TITLE
Make bower a peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Grunt Task for Installing Bower Dependencies
 
 ## Getting Started
 
-This plugin requires Grunt `~0.4.0`
+This plugin requires Grunt `>=0.4.0` and bower `~1.4.1`. Since version x.x.x bower is not a direct dependency anymore and 
+you need to require it directly.
 
 If you haven't used [Grunt](http://gruntjs.com/)
 before, be sure to check out the [Getting

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     },
     "main": "Gruntfile.js",
     "devDependencies": {
+        "bower":                "~1.4.1",
         "grunt":                "~0.4.5",
         "grunt-cli":            "~0.1.13",
         "grunt-contrib-jshint": "~0.11.1",
@@ -29,10 +30,10 @@
         "grunt-eslint":         "~10.0.0"
     },
     "dependencies": {
-        "bower":                "~1.4.1",
         "chalk":                "~1.0.0"
     },
     "peerDependencies": {
+        "bower":                "~1.4.1",
         "grunt":                ">=0.4.0"
     },
     "engines": {


### PR DESCRIPTION
Some OS have problems with long paths. Having bower as a direct dependency creates a problem on these OS. Furthermore, bower should be installed globally, some people already have it, so it is not necessary to install it twice.

Additionally you could also change the required version to relax it, to something like >= 1.4.x