### PR TITLE
chore: Replace chalk stripColor with strip-ansi

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     },
     "dependencies": {
         "bower":                "1.8.4",
-        "chalk":                "2.4.1"
+        "chalk":                "2.4.1",
+        "strip-ansi":           "4.0.0"
     },
     "peerDependencies": {
         "grunt":                ">=0.4.0"

--- a/tasks/grunt-bower-install-simple.js
+++ b/tasks/grunt-bower-install-simple.js
@@ -28,6 +28,7 @@
 
 /*  foreign modules  */
 var chalk         = require("chalk");
+var stripAnsi     = require('strip-ansi');
 var bower         = require("bower");
 var bowerRenderer = require("bower/lib/renderers/StandardRenderer");
 
@@ -100,7 +101,7 @@ module.exports = function (grunt) {
         /*  display header to explicitly inform user about our Bower operation  */
         var msg = chalk.blue("Executing Bower") + " (Command: " + chalk.green(options.command) + ")";
         if (options.color !== true)
-            msg = chalk.stripColor(msg);
+            msg = stripAnsi(msg);
         grunt.log.writeln(msg);
 
         /*  programatically run the Bower functionality  */


### PR DESCRIPTION
The stripColor function is no longer available from the chalk module,
and in their release notes they advise using the stand-alone
strip-ansi module.

Closes: rse/grunt-bower-install-simple#22

Signed-off-by: Dale Lane <dale.lane@uk.ibm.com>