### PR TITLE
update for security fixes in bower

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "grunt-eslint":         "21.0.0"
     },
     "dependencies": {
-        "bower":                "1.8.4",
+        "bower":                "1.8.8",
         "chalk":                "2.4.1",
         "strip-ansi":           "5.0.0"
     },


### PR DESCRIPTION
Node security working group found a vulnerability in Bower versions < 1.8.7 . This bumps the patch version so that this this package will install without critical security warnings.

Link to vulnerability
https://github.com/nodejs/security-wg/blob/master/vuln/npm/487.json